### PR TITLE
missed check

### DIFF
--- a/src/Form/Admin.php
+++ b/src/Form/Admin.php
@@ -77,7 +77,7 @@ class Admin extends FormBase {
           'mimetype_table',
         ]));
         foreach ($checked_mimetypes as $value) {
-          if (NestedArray::getValue($mimes_to_add, [$triggering_fieldset, $value])) {
+          if ($mimes_to_add && NestedArray::getValue($mimes_to_add, [$triggering_fieldset, $value])) {
             unset($mimes_to_add[$triggering_fieldset][$value]);
           }
           else {


### PR DESCRIPTION
This fixes an error where if you delete a mime without adding one there would be an error
```Recoverable fatal error: Argument 1 passed to Drupal\Component\Utility\NestedArray::getValue() must be of the type array, null given, called in /var/www/drupal8/modules/contrib/islandora_binary_object/src/Form/Admin.php on line 80 and defined in Drupal\Component\Utility\NestedArray::getValue() (line 69 of /var/www/drupal8/core/lib/Drupal/Component/Utility/NestedArray.php).```
