### PR TITLE
Add expected operator.

### DIFF
--- a/src/Form/Admin.php
+++ b/src/Form/Admin.php
@@ -312,7 +312,7 @@ class Admin extends FormBase {
           }
         }
         db_delete('islandora_binary_object_thumbnail_mappings')
-          ->condition('mimetype', $remove_db)
+          ->condition('mimetype', $remove_db, 'IN')
           ->execute();
       }
       // Now let's add everything.


### PR DESCRIPTION
D7 selected the default operator based on the type of value; however, D8 explicitly uses `=` by default.